### PR TITLE
indexer task error proofing

### DIFF
--- a/src/balancing.rs
+++ b/src/balancing.rs
@@ -79,7 +79,9 @@ pub fn decode_zswap_proof_params(
 }
 
 pub fn read_kzg_params() -> anyhow::Result<ParamsProver> {
-    let pp = concat!(env!("MIDNIGHT_LEDGER_STATIC_DIR"), "/kzg");
+    let pp = std::env::var("MIDNIGHT_LEDGER_STATIC_DIR")
+        .context("MIDNIGHT_LEDGER_STATIC_DIR not set")?
+        + "/kzg";
 
     ParamsProver::read(BufReader::new(
         File::open(pp).expect("failed to read kzg params"),


### PR DESCRIPTION
This handles a panic when querying/deserializing the contract state.

It also moves the status change outside the function, so that it catches all the errors, since otherwise the `?` was skipping it in some cases. For context, the purpose of setting the stat

Also fixes a small issue where the path to kzg is embedded statically, which doesn't let you move the binary to a different directory where it was built (unless the MIDNIGHT_LEDGER_STATIC_DIR is set to a non relative url in the same machine).