### PR TITLE
Automatically sets the correct platform for Apple Silicon and ARM devices

### DIFF
--- a/local-chain-setup/.envrc
+++ b/local-chain-setup/.envrc
@@ -1,1 +1,4 @@
 export COMPOSE_PROJECT_NAME=midnight_0_12_0_local_chain
+
+# Determine what platform architecture to use
+export DOCKER_DEFAULT_PLATFORM=linux/$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')

--- a/local-chain-setup/docker-compose.yml
+++ b/local-chain-setup/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   indexer:
     container_name: 'midnight-local-chain-indexer-0-12-0'
     image: 'midnightntwrk/indexer-standalone:2.1.1-rc.1-99b0bce4'
-    platform: linux/amd64
+    platform: ${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
     ports:
       - '8088:8088'
     command: ['-Dlogback.configurationFile=logback-json-file.xml']
@@ -28,7 +28,7 @@ services:
       - midnight-data-undeployed:/node
   node:
     image: 'midnightnetwork/midnight-node:0.12.0'
-    platform: linux/amd64
+    platform: ${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
     container_name: 'midnight-local-node-0-12-0'
     ports:
       - "9944:9944"


### PR DESCRIPTION
This fixes a bug for apple silicon and other ARM devices where docker compose up was failing without giving compelling error messages for what was wrong. 